### PR TITLE
fix java version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
     <version>2.0-beta</version>
 
     <properties>
-        <maven.compiler.source>1.17</maven.compiler.source>
-        <maven.compiler.target>1.17</maven.compiler.target>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <build>


### PR DESCRIPTION
later versions don't start with `1.` anymore !!

merges to origin/2.0 :)

i also added a newline at the end cos you forgot that bit